### PR TITLE
Show delivered history in modal

### DIFF
--- a/src/components/pedidos/DeliveredOrdersHistoryModal.tsx
+++ b/src/components/pedidos/DeliveredOrdersHistoryModal.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { Order } from '../../stores/orderStore';
+
+interface DeliveredOrdersHistoryModalProps {
+  orders: Order[];
+  deliveredDateFilter: string;
+  onDateFilterChange: (value: string) => void;
+  onClearFilter: () => void;
+  onClose: () => void;
+}
+
+export default function DeliveredOrdersHistoryModal({
+  orders,
+  deliveredDateFilter,
+  onDateFilterChange,
+  onClearFilter,
+  onClose,
+}: DeliveredOrdersHistoryModalProps) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4 py-6">
+      <div className="bg-white dark:bg-darkbg-lighter rounded-xl shadow-xl w-full max-w-5xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-darkbg">
+          <div>
+            <h2 className="text-lg font-bold text-primary-dark dark:text-white">
+              Historial de pedidos entregados
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Consulta los pedidos marcados como entregados y filtra por fecha de entrega.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-darkbg transition-colors"
+            aria-label="Cerrar historial"
+          >
+            <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <label htmlFor="delivered-date-filter" className="text-sm text-gray-700 dark:text-gray-200">
+                Fecha de entrega
+              </label>
+              <input
+                id="delivered-date-filter"
+                type="date"
+                value={deliveredDateFilter}
+                onChange={(event) => onDateFilterChange(event.target.value)}
+                className="px-3 py-2 rounded-lg border border-gray-300 dark:border-darkbg bg-white dark:bg-darkbg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-secondary"
+              />
+              {deliveredDateFilter && (
+                <button
+                  onClick={onClearFilter}
+                  className="text-sm text-primary dark:text-secondary hover:underline"
+                >
+                  Limpiar
+                </button>
+              )}
+            </div>
+
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-darkbg rounded-lg hover:bg-gray-200 dark:hover:bg-darkbg-darker transition-colors"
+            >
+              Cerrar
+            </button>
+          </div>
+
+          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-darkbg">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-darkbg">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-darkbg">
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Pedido
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Cliente
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Total
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Entregado
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white dark:bg-darkbg divide-y divide-gray-200 dark:divide-darkbg">
+                {orders.length > 0 ? (
+                  orders.map((order) => (
+                    <tr key={order.id} className="hover:bg-gray-50 dark:hover:bg-darkbg-darker transition-colors">
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">#{order.id}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {order.user ? `${order.user.first_name} ${order.user.last_name}` : 'Cliente'}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        S/. {order.total.toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+                        {order.delivered_at ? new Date(order.delivered_at).toLocaleString('es-PE') : '—'}
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-300">
+                      {deliveredDateFilter
+                        ? 'No se encontraron pedidos entregados para la fecha seleccionada.'
+                        : 'Aún no hay pedidos entregados registrados.'}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase';
 import PedidoCard from '../components/pedidos/PedidoCard';
 import PedidoDrawer from '../components/pedidos/PedidoDrawer';
 import PrintPreviewModal from '../components/pedidos/PrintPreviewModal';
+import DeliveredOrdersHistoryModal from '../components/pedidos/DeliveredOrdersHistoryModal';
 import SkeletonKanbanCard from '../components/skeletons/SkeletonKanbanCard';
 import { Printer, Plus, Trash2 } from 'lucide-react';
 import {
@@ -101,7 +102,27 @@ export default function Orders() {
   const [showPrintPreview, setShowPrintPreview] = React.useState(false);
   const [activeId, setActiveId] = React.useState<number | null>(null);
   const [isTouchDevice, setIsTouchDevice] = React.useState(false);
+  const [deliveredDateFilter, setDeliveredDateFilter] = React.useState('');
+  const [isHistoryModalOpen, setIsHistoryModalOpen] = React.useState(false);
   const { toast } = useToast();
+
+  const deliveredOrders = React.useMemo(() => {
+    const delivered = orders.filter((order) => order.status === 'Entregado' && order.delivered_at);
+
+    if (!deliveredDateFilter) {
+      return delivered;
+    }
+
+    return delivered.filter((order) => {
+      const deliveredDate = new Date(order.delivered_at as string);
+      if (Number.isNaN(deliveredDate.getTime())) {
+        return false;
+      }
+
+      const formattedDate = deliveredDate.toISOString().split('T')[0];
+      return formattedDate === deliveredDateFilter;
+    });
+  }, [orders, deliveredDateFilter]);
 
   // Enhanced device detection
   useEffect(() => {
@@ -395,6 +416,12 @@ export default function Orders() {
               <Printer className="w-4 h-4" />
               Prueba de Impresión
             </button>
+            <button
+              onClick={() => setIsHistoryModalOpen(true)}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary dark:bg-secondary rounded-xl hover:bg-primary-dark dark:hover:bg-secondary/90 transition-colors"
+            >
+              Ver historial
+            </button>
           </div>
         </div>
 
@@ -463,6 +490,16 @@ export default function Orders() {
 
       {showPrintPreview && (
         <PrintPreviewModal onClose={() => setShowPrintPreview(false)} />
+      )}
+
+      {isHistoryModalOpen && (
+        <DeliveredOrdersHistoryModal
+          orders={deliveredOrders}
+          deliveredDateFilter={deliveredDateFilter}
+          onDateFilterChange={setDeliveredDateFilter}
+          onClearFilter={() => setDeliveredDateFilter('')}
+          onClose={() => setIsHistoryModalOpen(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add a modal component for the delivered orders history table
- open the delivered orders history via a "Ver historial" button in the orders view
- keep the date filter controls inside the modal for consistent filtering

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e16a2fce008322a25bcbb27fd3dfb0