### PR TITLE
Weck-89: Validacion doble para pagos, filter by payment status.

### DIFF
--- a/src/stores/orderStore.ts
+++ b/src/stores/orderStore.ts
@@ -25,10 +25,13 @@ export interface OrderDetail {
   }>;
 }
 
+export type PaymentStatus = 'pending_payment' | 'paid' | 'payment_failed' | 'canceled';
+
 export interface Order {
   id: number;
   user_uuid: string;
   status: OrderStatus;
+  payment_status: PaymentStatus;
   total: number;
   created_at: string;
   started_at: string | null;
@@ -177,6 +180,7 @@ export const useOrderStore = create<OrderStore>((set, get) => {
               )
             )
           `)
+          .eq('payment_status', 'paid')
           .gte('created_at', startDate.toISOString())
           .lte('created_at', endDate.toISOString())
           .order('created_at', { ascending: false });
@@ -260,6 +264,7 @@ export const useOrderStore = create<OrderStore>((set, get) => {
               )
             )
           `)
+          .eq('payment_status', 'paid')
           .order('created_at', { ascending: false });
 
         if (error) throw error;


### PR DESCRIPTION
# 📝 Descripción breve
> Explica de forma concisa qué cambio introduce esta PR (qué problema resuelve, qué mejora agrega o qué funcionalidad implementa).

---

Se implementó el filtrado de órdenes en el fetch de OrderStore.ts para solo mostrar órdenes cuyo pago ha sido confirmado por Stripe como se indica en el ticket WECK-89.

## ✅ Checklist — Autor de la PR

Por favor marca las opciones que apliquen antes de solicitar revisión:

- [x] He revisado mi código y confirmo que cumple con los estándares basicos
- [x] He probado los cambios localmente (funcionalidad y edge cases)
- [x] El código compila y se ejecuta sin errores  
- [x] Esta PR es un **bug fix**
- [x] La rama se encuentra actualizada con la **rama principal o padre**

---

## 👀 Checklist — Revisor

El revisor debe verificar y marcar lo siguiente antes de aprobar el merge:

- [x] No existen conflictos que impidan realizar el merge.
- [x] El nombre de la rama incluye el **ID de la story de Jira**
- [x] Todos los comentarios han sido atendidos y resueltos


---

### 🧩 Notas adicionales (opcional)
> Agrega aquí contexto adicional, capturas de pantalla, logs o cualquier detalle relevante para entender el cambio.
