### PR TITLE
WECK-185: Consultas para metricas y generacion de graficas corregidas

### DIFF
--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { DivideIcon as LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 import { formatCurrency } from '../utils/formatCurrency';
@@ -13,6 +14,7 @@ interface Props {
     isPositive: boolean;
   };
   isCurrency?: boolean;
+  to?: string; 
 }
 
 const colorVariants = {
@@ -42,7 +44,7 @@ const colorVariants = {
   }
 };
 
-export default function DashboardCard({ title, value, icon: Icon, color, trend, isCurrency }: Props) {
+function CardContent({ title, value, icon: Icon, color, trend, isCurrency }: Props) {
   const colorClasses = colorVariants[color];
   const displayValue = isCurrency ? formatCurrency(value as number) : value;
 
@@ -83,4 +85,18 @@ export default function DashboardCard({ title, value, icon: Icon, color, trend, 
       </div>
     </div>
   );
+}
+
+export default function DashboardCard(props: Props) {
+  const { to } = props;
+
+  if (to) {
+    return (
+      <NavLink to={to} className="block cursor-pointer">
+        <CardContent {...props} />
+      </NavLink>
+    );
+  }
+
+  return <CardContent {...props} />;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -182,6 +182,7 @@ export default function Dashboard() {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* --- GRÁFICA DE VENTAS POR DÍA  --- */}
           <div className="bg-white dark:bg-darkbg-lighter rounded-xl shadow-soft dark:shadow-dark p-6">
             <h2 className="text-lg font-bold text-primary-dark dark:text-white mb-6">
               Ventas por Día
@@ -197,7 +198,8 @@ export default function Dashboard() {
                       dataKey="date"
                       tick={{ fontSize: 12 }}
                       tickFormatter={(value) => {
-                        const date = new Date(value);
+                        const date = new Date(value + 'T12:00:00');
+                        
                         return date.toLocaleDateString('es-PE', {
                           day: '2-digit',
                           month: 'short'
@@ -215,7 +217,7 @@ export default function Dashboard() {
                     <Tooltip
                       content={<CustomTooltip
                         labelFormatter={(label: string) => {
-                          const date = new Date(label);
+                          const date = new Date(label + 'T12:00:00');
                           return date.toLocaleDateString('es-PE', {
                             weekday: 'long',
                             year: 'numeric',
@@ -241,6 +243,7 @@ export default function Dashboard() {
             </div>
           </div>
 
+          {/* --- GRÁFICA TOP 5 PRODUCTOS --- */}
           <div className="bg-white dark:bg-darkbg-lighter rounded-xl shadow-soft dark:shadow-dark p-6">
             <h2 className="text-lg font-bold text-primary-dark dark:text-white mb-6">
               Top 5 Productos
@@ -259,7 +262,7 @@ export default function Dashboard() {
                     <XAxis
                       type="number"
                       tick={{ fontSize: 12 }}
-                      tickFormatter={(value) => `$${value}`}
+                      tickFormatter={(value) => `${value}`} 
                       className="dark:text-gray-300"
                       stroke="#9ca3af"
                     />
@@ -272,12 +275,29 @@ export default function Dashboard() {
                       stroke="#9ca3af"
                     />
                     <Tooltip
-                      content={<CustomTooltip
-                        valueFormatter={(value: number) => `$${value}`}
-                      />}
+                      cursor={{ fill: 'transparent' }}
+                      content={({ active, payload }) => {
+                        if (active && payload && payload.length) {
+                          const data = payload[0].payload;
+                          return (
+                            <div className="bg-white dark:bg-darkbg-lighter border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+                              <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+                                {data.name}
+                              </p>
+                              <p className="text-sm text-gray-700 dark:text-gray-300">
+                                <span className="font-medium">Ventas:</span> ${data.total.toFixed(2)}
+                              </p>
+                              <p className="text-sm text-gray-700 dark:text-gray-300">
+                                <span className="font-medium">Unidades:</span> {data.quantity}
+                              </p>
+                            </div>
+                          );
+                        }
+                        return null;
+                      }}
                     />
                     <Bar
-                      dataKey="total"
+                      dataKey="quantity" 
                       radius={[0, 8, 8, 0]}
                     >
                       {metrics.topProducts.map((_, index) => (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -144,6 +144,7 @@ export default function Dashboard() {
                 value={metrics.totalOrders}
                 icon={ShoppingBag}
                 color="primary"
+                to="/historico" 
               />
               <DashboardCard
                 title="Ventas"
@@ -157,6 +158,7 @@ export default function Dashboard() {
                 value={metrics.activeProducts}
                 icon={Coffee}
                 color="secondary"
+                to="/productos" 
               />
               <DashboardCard
                 title="Promedio de Venta"
@@ -170,6 +172,7 @@ export default function Dashboard() {
                 value={metrics.totalUsers}
                 icon={Users}
                 color="primary"
+                to="/alumnos"
               />
               <DashboardCard
                 title="Nuevos Usuarios"

--- a/src/stores/dashboardStore.ts
+++ b/src/stores/dashboardStore.ts
@@ -11,29 +11,30 @@ interface DateRange {
 }
 
 interface DashboardMetrics {
-  totalOrders: number;
-  totalSales: number;
-  activeProducts: number;
-  totalUsers: number;
-  newUsers: number;
+  totalOrders: number;      // Pedidos (excepto 'creando')
+  totalSales: number;       // Ventas (solo 'paid')
+  activeProducts: number;   // Productos Activos
+  totalUsers: number;       // Usuarios Totales (alumnos)
+  newUsers: number;         // Nuevos Usuarios (en rango)
+  averageSale: number;      // Promedio de Venta (solo 'paid')
   topProducts: Array<{
     name: string;
     total: number;
     quantity: number;
-  }>;
+  }>;                      // Top 5 Productos (por cantidad, 'paid')
   recentSales: Array<{
     date: string;
     total: number;
-  }>;
+  }>;                      // Ventas por Día ('paid')
   peakHours: Array<{
     hour: number;
     count: number;
-  }>;
+  }>;                      // Horas Pico 
   topCustomers: Array<{
     name: string;
     orders: number;
     total: number;
-  }>;
+  }>;                   // Top Clientes (por pedidos, 'paid')
 }
 
 interface DashboardState {
@@ -53,6 +54,7 @@ const initialMetrics: DashboardMetrics = {
   activeProducts: 0,
   totalUsers: 0,
   newUsers: 0,
+  averageSale: 0,
   topProducts: [],
   recentSales: [],
   peakHours: [],
@@ -78,7 +80,6 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       set({ loading: true, error: null });
       const { dateRange } = get();
 
-      // Get orders within date range
       const { data: ordersData, error: ordersError } = await supabase
         .from('orders')
         .select(`
@@ -86,6 +87,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           total,
           created_at,
           status,
+          payment_status,
           user:users(
             uuid,
             first_name,
@@ -97,10 +99,17 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 
       if (ordersError) throw ordersError;
 
-      const totalOrders = ordersData?.length || 0;
-      const totalSales = ordersData?.reduce((sum, order) => sum + (order.total || 0), 0) || 0;
+      const validOrdersForTotalCount = ordersData?.filter(o => o.status !== 'Creando') || [];
+      const totalOrders = validOrdersForTotalCount.length;
 
-      // Get active products
+      const paidOrders = ordersData?.filter(o => o.payment_status === 'paid') || [];
+      const totalSales = paidOrders.reduce((sum, order) => sum + (order.total || 0), 0);
+      
+      const totalPaidOrders = paidOrders.length;
+      const averageSale = totalPaidOrders > 0 ? totalSales / totalPaidOrders : 0;
+      console.log('Ordenes pagadas: ', totalPaidOrders);
+      console.log('Ordenes totales: ', totalOrders);
+
       const { count: activeProducts, error: productsError } = await supabase
         .from('products')
         .select('*', { count: 'exact', head: true })
@@ -108,7 +117,6 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 
       if (productsError) throw productsError;
 
-      // Get user metrics
       const { data: usersData, error: usersError } = await supabase
         .from('users')
         .select('uuid, created_at');
@@ -120,7 +128,6 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         parseISO(user.created_at) >= dateRange.startDate
       ).length || 0;
 
-      // Get top products with quantities
       const { data: topProductsData, error: topProductsError } = await supabase
         .from('order_details')
         .select(`
@@ -128,8 +135,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           subtotal,
           product_id,
           product:products(name),
-          order:orders!inner(created_at)
+          order:orders!inner(created_at, payment_status)
         `)
+        .eq('order.payment_status', 'paid') // Solo pedidos 'paid'
         .gte('order.created_at', dateRange.startDate.toISOString())
         .lte('order.created_at', dateRange.endDate.toISOString());
 
@@ -157,12 +165,24 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       });
 
       const topProducts = Array.from(productMap.values())
-        .sort((a, b) => b.total - a.total)
+        .sort((a, b) => b.quantity - a.quantity)
         .slice(0, 5);
 
-      // Calculate peak hours
-      const hourCounts = ordersData?.reduce((acc: { [key: number]: number }, order) => {
-        const hour = new Date(order.created_at).getHours();
+      const { data: peakHoursData, error: peakHoursError } = await supabase
+        .from('orders')
+        .select('created_at, scheduled_delivery_time')
+        .not('status', 'eq', 'Creando') 
+        .gte('created_at', dateRange.startDate.toISOString())
+        .lte('created_at', dateRange.endDate.toISOString());
+        
+      if (peakHoursError) throw peakHoursError;
+
+      const hourCounts = peakHoursData?.reduce((acc: { [key: number]: number }, order) => {
+        const baseDate = order.scheduled_delivery_time 
+          ? new Date(order.scheduled_delivery_time) 
+          : new Date(order.created_at);
+
+        const hour = baseDate.getHours();
         acc[hour] = (acc[hour] || 0) + 1;
         return acc;
       }, {});
@@ -172,29 +192,43 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         .sort((a, b) => b.count - a.count)
         .slice(0, 5);
 
-      // Calculate top customers
-      const customerOrders = ordersData?.reduce((acc: { [key: string]: any }, order) => {
-        const userId = order.user?.uuid;
+      const { data: topCustomersData, error: topCustomersError } = await supabase
+        .from('orders')
+        .select(`
+          total,
+          user:users!inner(
+            uuid,
+            first_name,
+            last_name
+          )
+        `)
+        .eq('payment_status', 'paid')
+        .gte('created_at', dateRange.startDate.toISOString())
+        .lte('created_at', dateRange.endDate.toISOString());
+
+      if (topCustomersError) throw topCustomersError;
+
+      const customerOrders = topCustomersData?.reduce((acc: { [key: string]: any }, order) => {
+        const userId = order.user.uuid;
         if (!userId) return acc;
 
         if (!acc[userId]) {
           acc[userId] = {
-            name: `${order.user.first_name} ${order.user.last_name}`,
+            name: `${order.user.first_name || ''} ${order.user.last_name || ''}`.trim(),
             orders: 0,
             total: 0
           };
         }
 
-        acc[userId].orders++;
+        acc[userId].orders++; 
         acc[userId].total += order.total || 0;
         return acc;
       }, {});
 
       const topCustomers = Object.values(customerOrders || {})
-        .sort((a: any, b: any) => b.total - a.total)
+        .sort((a: any, b: any) => b.orders - a.orders) 
         .slice(0, 5);
 
-      // Calculate daily sales
       const startDay = startOfDay(dateRange.startDate);
       const endDay = startOfDay(dateRange.endDate);
       const daysDiff = Math.ceil((endDay.getTime() - startDay.getTime()) / (1000 * 60 * 60 * 24)) + 1;
@@ -208,8 +242,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         };
       });
 
-      ordersData?.forEach(order => {
-        const orderDate = format(new Date(order.created_at), 'yyyy-MM-dd');
+      paidOrders?.forEach(order => {
+        const localDate = new Date(order.created_at);
+        const orderDate = format(localDate, 'yyyy-MM-dd');
         const dayData = dailySales.find(day => day.date === orderDate);
         if (dayData) {
           dayData.total += order.total || 0;
@@ -223,6 +258,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           activeProducts: activeProducts || 0,
           totalUsers,
           newUsers,
+          averageSale,
           topProducts,
           recentSales: dailySales,
           peakHours,
@@ -241,7 +277,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   exportToPDF: () => {
-    const { metrics } = get();
+    const { metrics, dateRange } = get();
     if (!metrics) return;
 
     const doc = new jsPDF();
@@ -253,7 +289,6 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 
     // Add date range
     doc.setFontSize(12);
-    const { dateRange } = get();
     doc.text(
       `Período: ${format(dateRange.startDate, 'dd/MM/yyyy')} - ${format(dateRange.endDate, 'dd/MM/yyyy')}`,
       pageWidth / 2,
@@ -268,6 +303,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     const summaryData = [
       ['Total de Pedidos', metrics.totalOrders.toString()],
       ['Ventas Totales', `S/ ${metrics.totalSales.toFixed(2)}`],
+      ['Promedio de Venta', `S/ ${metrics.averageSale.toFixed(2)}`], // <-- AÑADIDO
       ['Productos Activos', metrics.activeProducts.toString()],
       ['Usuarios Totales', metrics.totalUsers.toString()],
       ['Nuevos Usuarios', metrics.newUsers.toString()],
@@ -280,7 +316,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     });
 
     // Add top products
-    doc.text('Top 5 Productos', 20, doc.lastAutoTable.finalY + 20);
+    doc.text('Top 5 Productos', 20, (doc as any).lastAutoTable.finalY + 20);
     
     const productsData = metrics.topProducts.map(product => [
       product.name,
@@ -289,9 +325,24 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     ]);
 
     autoTable(doc, {
-      startY: doc.lastAutoTable.finalY + 25,
+      startY: (doc as any).lastAutoTable.finalY + 25,
       head: [['Producto', 'Cantidad', 'Total']],
       body: productsData,
+    });
+    
+    // Add top customers
+    doc.text('Top 5 Clientes (Histórico)', 20, (doc as any).lastAutoTable.finalY + 20);
+    
+    const customersData = metrics.topCustomers.map(customer => [
+      customer.name,
+      customer.orders.toString(),
+      `S/ ${customer.total.toFixed(2)}`,
+    ]);
+
+    autoTable(doc, {
+      startY: (doc as any).lastAutoTable.finalY + 25,
+      head: [['Cliente', 'N° Pedidos', 'Total Gastado']],
+      body: customersData,
     });
 
     // Save the PDF
@@ -312,11 +363,11 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       ['Métrica', 'Valor'],
       ['Total de Pedidos', metrics.totalOrders],
       ['Ventas Totales', metrics.totalSales],
+      ['Promedio de Venta', metrics.averageSale], // <-- AÑADIDO
       ['Productos Activos', metrics.activeProducts],
       ['Usuarios Totales', metrics.totalUsers],
       ['Nuevos Usuarios', metrics.newUsers],
     ];
-
     const summarySheet = utils.aoa_to_sheet(summaryData);
     utils.book_append_sheet(workbook, summarySheet, 'Resumen');
 
@@ -329,9 +380,31 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         product.total,
       ]),
     ];
-
     const productsSheet = utils.aoa_to_sheet(productsData);
     utils.book_append_sheet(workbook, productsSheet, 'Top Productos');
+    
+    // Top Customers sheet
+    const customersData = [
+      ['Cliente', 'N° Pedidos', 'Total Gastado'],
+      ...metrics.topCustomers.map(customer => [
+        customer.name,
+        customer.orders,
+        customer.total,
+      ]),
+    ];
+    const customersSheet = utils.aoa_to_sheet(customersData);
+    utils.book_append_sheet(workbook, customersSheet, 'Top Clientes');
+    
+    // Daily Sales sheet
+    const dailySalesData = [
+      ['Fecha', 'Ventas Totales'],
+      ...metrics.recentSales.map(day => [
+        day.date,
+        day.total,
+      ]),
+    ];
+    const dailySalesSheet = utils.aoa_to_sheet(dailySalesData);
+    utils.book_append_sheet(workbook, dailySalesSheet, 'Ventas Diarias');
 
     // Save the file
     writeFile(workbook, 'dashboard-report.xlsx');


### PR DESCRIPTION
# 📝 Descripción breve
> Explica de forma concisa qué cambio introduce esta PR (qué problema resuelve, qué mejora agrega o qué funcionalidad implementa).

Consultas para metricas y generacion de graficas corregidas. 

Se agregaron filtros para usar el campo payment_status solo cuando es 'paid' para filtrar pedidos exitosos, entre otras nuevas restricciones.

Se cambiaron las gráficas de Horas Pico y Top Clientes para dejar de mostrar el registro histórico y en su lugar tomar en cuenta el rango de fechas seleccionado, al igual que lo hacía el resto de gráficas.

Se cambió la gráfica de Top 5 Productos para mostrar en el eje X la cantidad de unidades en lugar del dinero generado. El dinero generado por las ventas se puede seguir viendo al hacer hover.

## ✅ Checklist — Autor de la PR

Por favor marca las opciones que apliquen antes de solicitar revisión:

- [x] He revisado mi código y confirmo que cumple con los estándares basicos
- [x] He probado los cambios localmente (funcionalidad y edge cases)
- [x] El código compila y se ejecuta sin errores  
- [x] Esta PR es un **bug fix**
- [x] La rama se encuentra actualizada con la **rama principal o padre**

---

## 👀 Checklist — Revisor

El revisor debe verificar y marcar lo siguiente antes de aprobar el merge:

- [x] No existen conflictos que impidan realizar el merge.
- [x] El nombre de la rama incluye el **ID de la story de Jira**
- [x] Todos los comentarios han sido atendidos y resueltos


---

### 🧩 Notas adicionales (opcional)
> Agrega aquí contexto adicional, capturas de pantalla, logs o cualquier detalle relevante para entender el cambio.
